### PR TITLE
Using Java NIO API instead of Java IO API

### DIFF
--- a/src/main/java/org/simplify4u/plugins/sign/ArtifactSigner36.java
+++ b/src/main/java/org/simplify4u/plugins/sign/ArtifactSigner36.java
@@ -16,9 +16,9 @@
 package org.simplify4u.plugins.sign;
 
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import javax.inject.Named;
@@ -41,7 +41,7 @@ public class ArtifactSigner36 extends ArtifactSigner {
 
         verifyArtifact(artifact);
 
-        try (InputStream artifactInputStream = new BufferedInputStream(new FileInputStream(artifact.getFile()))) {
+        try (InputStream artifactInputStream = new BufferedInputStream(Files.newInputStream(artifact.getFile().toPath()))) {
             return Collections.singletonList(makeSignature(artifactInputStream,
                     artifact.getArtifactId(),
                     artifact.getClassifier(),

--- a/src/main/java/org/simplify4u/plugins/sign/ArtifactSigner40.java
+++ b/src/main/java/org/simplify4u/plugins/sign/ArtifactSigner40.java
@@ -16,9 +16,9 @@
 package org.simplify4u.plugins.sign;
 
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -63,7 +63,7 @@ public class ArtifactSigner40 extends ArtifactSigner {
         try {
             if (transformersForArtifact.isEmpty()) {
                 try (InputStream artifactInputStream = new BufferedInputStream(
-                        new FileInputStream(srcArtifact.getFile()))) {
+                        Files.newInputStream(srcArtifact.getFile().toPath()))) {
                     result.add(makeSignature(artifactInputStream,
                             srcArtifact.getArtifactId(),
                             srcArtifact.getClassifier(),

--- a/src/test/java/org/simplify4u/plugins/sign/openpgp/PGPKeyInfoTest.java
+++ b/src/test/java/org/simplify4u/plugins/sign/openpgp/PGPKeyInfoTest.java
@@ -16,8 +16,8 @@
 package org.simplify4u.plugins.sign.openpgp;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -36,7 +36,7 @@ class PGPKeyInfoTest {
     private static final File KEY_FILE = new File(PGPKeyInfo.class.getResource("/priv-key-no-pass.asc").getFile());
 
     @Test
-    void keyFromFileAllPropertiesSet() throws FileNotFoundException {
+    void keyFromFileAllPropertiesSet() throws IOException {
 
         // when
         PGPKeyInfo keyInfo = PGPKeyInfo.builder()
@@ -48,12 +48,12 @@ class PGPKeyInfoTest {
         // then
         assertThat(keyInfo.getId()).isEqualTo(KEY_ID);
         assertThat(keyInfo.getPass()).isEqualTo(KEY_PASS);
-        assertThat(keyInfo.getKey()).hasSameContentAs(new FileInputStream(KEY_FILE));
+        assertThat(keyInfo.getKey()).hasSameContentAs(Files.newInputStream(KEY_FILE.toPath()));
     }
 
 
     @Test
-    void keyFromFile() throws FileNotFoundException {
+    void keyFromFile() throws IOException {
 
         // when
         PGPKeyInfo keyInfo = PGPKeyInfo.builder()
@@ -63,7 +63,7 @@ class PGPKeyInfoTest {
         // then
         assertThat(keyInfo.getId()).isNull();
         assertThat(keyInfo.getPass()).isNull();
-        assertThat(keyInfo.getKey()).hasSameContentAs(new FileInputStream(KEY_FILE));
+        assertThat(keyInfo.getKey()).hasSameContentAs(Files.newInputStream(KEY_FILE.toPath()));
     }
 
     @Test


### PR DESCRIPTION
This PR replaces some uses of Java IO API by Java NIO API for two reasons:
* Potentially better performance
* More modern (Java 7 vs. Java 6)