### PR TITLE
Clear environment variable before tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,18 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedEnvironmentVariables>
+                                <!-- exclude configuration variable from test environment -->
+                                <excludedVariable>SIGN_KEY</excludedVariable>
+                                <excludedVariable>SIGN_KEY_ID</excludedVariable>
+                                <excludedVariable>SIGN_KEY_PASS</excludedVariable>
+                            </excludedEnvironmentVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
                             <execution>
@@ -358,6 +370,11 @@
                             <settingsFile>src/it/settings.xml</settingsFile>
                             <showErrors>true</showErrors>
                             <showVersion>true</showVersion>
+                            <environmentVariables>
+                                <SIGN_KEY/>
+                                <SIGN_KEY_ID/>
+                                <SIGN_KEY_PASS/>
+                            </environmentVariables>
                         </configuration>
                         <executions>
                             <execution>

--- a/src/main/java/org/simplify4u/plugins/sign/openpgp/PGPKeyInfo.java
+++ b/src/main/java/org/simplify4u/plugins/sign/openpgp/PGPKeyInfo.java
@@ -50,18 +50,32 @@ public class PGPKeyInfo {
     @Builder
     private PGPKeyInfo(String keyId, String keyPass, File keyFile) {
 
-        id = Optional.ofNullable(Optional.ofNullable(System.getenv(SIGN_KEY_ID_ENV)).orElse(keyId))
+        id = Optional.ofNullable(stringFromEnv(SIGN_KEY_ID_ENV).orElse(keyId))
                 .map(PGPKeyInfo::parseKeyId)
                 .orElse(null);
 
-        pass = Optional.ofNullable(Optional.ofNullable(System.getenv(SIGN_KEY_PASS_ENV)).orElse(keyPass))
+        pass = Optional.ofNullable(stringFromEnv(SIGN_KEY_PASS_ENV).orElse(keyPass))
                 .map(String::toCharArray)
                 .orElse(null);
 
-        key = Optional.ofNullable(System.getenv(SIGN_KEY_ENV))
+        key = stringFromEnv(SIGN_KEY_ENV)
                 .map(String::trim)
                 .map(PGPKeyInfo::keyFromString)
                 .orElseGet(() -> keyFromFile(keyFile));
+    }
+
+    /**
+     * Read environment variable and filter by "null" string - this value is set be invoker-maven-plugin.
+     * <p>
+     * TODO - remove workaround after fix and release https://issues.apache.org/jira/browse/MINVOKER-273
+     *
+     * @param environmentName a environment variable name
+     *
+     * @return content of environment variable or empty if not exist.
+     */
+    private static Optional<String> stringFromEnv(String environmentName) {
+        return Optional.ofNullable(System.getenv(environmentName))
+                .filter(s -> !"null".equals(s));
     }
 
     private static InputStream keyFromFile(File keyFile) {

--- a/src/test/java/org/simplify4u/plugins/sign/openpgp/PGPKeyInfoTest.java
+++ b/src/test/java/org/simplify4u/plugins/sign/openpgp/PGPKeyInfoTest.java
@@ -108,4 +108,18 @@ class PGPKeyInfoTest {
                 .hasMessageStartingWith("Invalid keyId: For input string: \"xxx\"")
                 .hasNoCause();
     }
+
+    @Test
+    @SetEnvironmentVariable(key = "SIGN_KEY", value = "signKey from environment")
+    @SetEnvironmentVariable(key = "SIGN_KEY_ID", value = "null")
+    void nullStringInEnvironmentValueShouldBeFiltered() {
+        // when
+        PGPKeyInfo keyInfo = PGPKeyInfo.builder()
+                .build();
+
+        // then
+        assertThat(keyInfo.getId()).isNull();
+        assertThat(keyInfo.getPass()).isNull();
+        assertThat(keyInfo.getKey()).hasContent("signKey from environment");
+    }
 }


### PR DESCRIPTION
CI or system environment variables shouldn't have impact on test.
So we need remove configuration variable from environment before tests.

It is some bug / miss feature in invoker-maven-plugin - no possibility to remove / exclude environment variable. When we try to set empty value - string "null" is set as value.