### PR TITLE
WIP: [19] Assert signature file name syntax

### DIFF
--- a/src/it/big-artifact/postbuild.groovy
+++ b/src/it/big-artifact/postbuild.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Markus Karg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Files
+
+def target = basedir.toPath().resolve( "target" )
+def pomSignature = target.resolve( "big-artifact-1.1.1.pom.asc" )
+def datSignature = target.resolve( "big-artifact-1.1.1.dat.asc" )
+
+assert Files.exists( pomSignature )
+assert Files.exists( datSignature )

--- a/src/it/pom-packaging/postbuild.groovy
+++ b/src/it/pom-packaging/postbuild.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Markus Karg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Files
+
+def target = basedir.toPath().resolve( "target" )
+def pomSignature = target.resolve( "pom-packaging-1.1.1.pom.asc" )
+
+assert Files.exists( pomSignature )

--- a/src/it/standard-packaging/postbuild.groovy
+++ b/src/it/standard-packaging/postbuild.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Markus Karg
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.file.Files
+
+def target = basedir.toPath().resolve( "target" )
+def pomSignature = target.resolve( "standard-packaging-1.1.1.pom.asc" )
+def jarSignature = target.resolve( "standard-packaging-1.1.1.jar.asc" )
+def datSignature = target.resolve( "standard-packaging-1.1.1.dat.asc" )
+def c1DatSignature = target.resolve( "standard-packaging-c1-1.1.1.dat.asc" )
+
+assert Files.exists( pomSignature )
+assert Files.exists( jarSignature )
+assert Files.exists( datSignature )
+assert Files.exists( c1DatSignature )


### PR DESCRIPTION
This is a first draft of a possible solution for issue #19.

What I am stuck with is how I can access the IT maven project instance from within the `postbuild.groovy` script? I need that to solve the following issues:
- SHOULD NOT hard code the version number in the script, as it would imply to change all scripts again and again for each new version of the project.
- SHOULD NOT hard code the expected file name as a literal, as it would imply to change the script again if more signature files are added to the existing IT test case.

Closes #19
